### PR TITLE
Fix empty todo JSON handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,8 +8,12 @@ class ToDoList:
 
     def load(self):
         if os.path.exists(self.filename):
-            with open(self.filename, "r") as f:
-                return json.load(f)
+            try:
+                with open(self.filename, "r") as f:
+                    return json.load(f)
+            except json.JSONDecodeError:
+                # Handle empty or corrupt JSON files gracefully
+                return []
         return []
 
     def save(self):


### PR DESCRIPTION
## Summary
- handle empty or corrupt todo files gracefully by catching JSONDecodeError in `load`

## Testing
- `python3 - <<'EOF'
from main import ToDoList

todo = ToDoList()
print(todo.todos)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_687fa8829ee8832bb3a9bde8e6c7eaaa